### PR TITLE
chore(vercel-app-playground): replace barrel import

### DIFF
--- a/vercel-app-playground/src/routes/streaming/_components/header.tsx
+++ b/vercel-app-playground/src/routes/streaming/_components/header.tsx
@@ -1,8 +1,6 @@
 import { NextLogoLight } from '#/ui/next-logo';
-import {
-  MagnifyingGlassIcon,
-  ShoppingCartIcon,
-} from '@heroicons/react/24/solid';
+import MagnifyingGlassIcon from '@heroicons/react/24/solid/MagnifyingGlassIcon';
+import ShoppingCartIcon from '@heroicons/react/24/solid/ShoppingCartIcon';
 import { CartCount } from './cart-count';
 import { Link } from '@hiogawa/react-server/client';
 

--- a/vercel-app-playground/src/ui/external-link.tsx
+++ b/vercel-app-playground/src/ui/external-link.tsx
@@ -1,4 +1,4 @@
-import { ArrowRightIcon } from '@heroicons/react/24/outline';
+import ArrowRightIcon from '@heroicons/react/24/outline/ArrowRightIcon';
 
 export const ExternalLink = ({
   children,

--- a/vercel-app-playground/src/ui/global-nav.tsx
+++ b/vercel-app-playground/src/ui/global-nav.tsx
@@ -3,7 +3,8 @@
 import { demos, type Item } from '#/lib/demos';
 import { NextLogoDark } from '#/ui/next-logo';
 import { Link, useRouter } from '@hiogawa/react-server/client';
-import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/solid';
+import XMarkIcon from '@heroicons/react/24/solid/XMarkIcon';
+import Bars3Icon from '@heroicons/react/24/solid/Bars3Icon';
 import clsx from 'clsx';
 import { useState } from 'react';
 import Byline from './byline';

--- a/vercel-app-playground/src/ui/mobile-nav-toggle.tsx
+++ b/vercel-app-playground/src/ui/mobile-nav-toggle.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/solid';
+import Bars3Icon from '@heroicons/react/24/solid/Bars3Icon';
+import XMarkIcon from '@heroicons/react/24/solid/XMarkIcon';
 import clsx from 'clsx';
 import React from 'react';
 

--- a/vercel-app-playground/src/ui/product-rating.tsx
+++ b/vercel-app-playground/src/ui/product-rating.tsx
@@ -1,4 +1,4 @@
-import { StarIcon } from '@heroicons/react/24/solid';
+import StarIcon from '@heroicons/react/24/solid/StarIcon';
 import clsx from 'clsx';
 
 export const ProductRating = ({ rating }: { rating: number }) => {


### PR DESCRIPTION
I thought this might be affecting slow startup (though obviously way faster than Next.js), but it doesn't look this matter.
Here is the draft PR just for the record.

```
$ pnpm dev --force

> @ dev /home/hiroshi/code/personal/rsc-on-vite/vercel-app-playground
> vite "--force"

Forced re-optimization of dependencies

  VITE v5.2.12  ready in 239 ms

  ➜  Local:   http://localhost:5173/
  ➜  Network: use --host to expose
  ➜  press h + enter to show help
  --> GET /
  <-- GET / 200 2.3s
```